### PR TITLE
Update switchbot_15_amp_w1901400.md

### DIFF
--- a/docs/devices/plugs/switchbot_15_amp_w1901400.md
+++ b/docs/devices/plugs/switchbot_15_amp_w1901400.md
@@ -144,7 +144,8 @@ light:
     internal: true
     name: ${display_name} White LED
     id: white_led
-    output: white_output    
+    output: white_output
+    restore_mode: RESTORE_DEFAULT_OFF
 
 output:
   - id: white_output


### PR DESCRIPTION
In esphome 2023.4.0 they changed the default restore mode on lights making the light not come back on when the plug is rebooted...