### PR TITLE
add workaround for switchbot boot loop issues on ESPHome

### DIFF
--- a/docs/devices/plugs/switchbot_15_amp_w1901400.md
+++ b/docs/devices/plugs/switchbot_15_amp_w1901400.md
@@ -65,6 +65,12 @@ esp32:
 
 logger:
 api:
+  # fixes boot loop issues in esphome 12.5+
+  on_client_connected:
+    - esp32_ble_tracker.start_scan:
+        continuous: true
+  on_client_disconnected:
+    - esp32_ble_tracker.stop_scan:
 ota:
 
 button:
@@ -84,6 +90,7 @@ esp32_ble_tracker:
 #    interval: 1100ms
 #    window: 1100ms
     active: true
+    continuous: false # fixes boot loop issues in esphome 12.5+
 
 bluetooth_proxy:
   active: true


### PR DESCRIPTION
Users have reported boot loop issues on ESPHome with the C3 chips. This includes the one on the popular Switchbot 15A plug. 

Adding some logic to the api and to the ble tracker seems to fix this issue.

This adds the workaround to the esphome YAML for the Switchbot plug.